### PR TITLE
Fix for CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')

### DIFF
--- a/packages/cli/src/utils/directory/removeDir.ts
+++ b/packages/cli/src/utils/directory/removeDir.ts
@@ -7,5 +7,6 @@ export const removeDir = (
   projectDir: string,
   dirName: string
 ): Promise<boolean> => {
-  return removeFileOrDirectory(path.join(projectDir, dirName));
+  const safeDirName = path.basename(dirName);
+  return removeFileOrDirectory(path.join(projectDir, safeDirName));
 };


### PR DESCRIPTION
[Corgea](https://www.corgea.com) is an AI security engineer that fixes vulnerable code.

It issued this PR to fix a vulnerability for you to review.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/76770eaf-3615-4daa-8bda-4e157f5975d3)

### Explanation of the issue
CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
The product uses external input to construct a pathname that is intended to identify a file or directory that is located underneath a restricted parent directory, but the product does not properly neutralize special elements within the pathname that can cause the pathname to resolve to a location that is outside of the restricted directory.

Many file operations are intended to take place within a restricted directory. By using special elements such as ".." and "/" separators, attackers can escape outside of the restricted location to access files or directories that are elsewhere on the system. One of the most common special elements is the "../" sequence, which in most modern operating systems is interpreted as the parent directory of the current location. This is referred to as relative path traversal. Path traversal also covers the use of absolute pathnames such as "/usr/local/bin", which may also be useful in accessing unexpected files. This is referred to as absolute path traversal.
In many programming languages, the injection of a null byte (the 0 or NUL) may allow an attacker to truncate a generated filename to widen the scope of attack. For example, the product may add ".txt" to any pathname, thus limiting the attacker to text files, but a null injection may effectively remove this restriction.


### Explanation of the fix
The fix addresses a Path Traversal vulnerability by ensuring that the directory name used in the 'removeDir' function is always a base name, not a path, thus preventing directory traversal attacks.
- The vulnerability was due to the use of external input to construct a pathname without neutralizing special elements like ".." or "/" which could lead to path traversal.
- The fix involves using the 'path.basename' function on the 'dirName' variable. This function returns the last portion of a path, effectively stripping any preceding directories.
- By doing this, even if an attacker tries to use special elements to traverse directories, the 'path.basename' function will only consider the actual directory name, not the traversal path.
- This ensures that the 'removeDir' function can only remove files or directories within the specified 'projectDir', thus limiting the scope of potential attacks.
- It's important to note that this fix also prevents null byte injection attacks as the 'path.basename' function would treat a null byte as part of the directory name, not as a string terminator.